### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://a-f-almalki.visualstudio.com/d96385bd-3ed0-4ee5-bebf-1717dbf62e74/fc38d75d-0bec-43eb-a290-2f2846700235/_apis/work/boardbadge/f8d63ebe-9e88-4ac7-9e23-44b1fde891e1)](https://a-f-almalki.visualstudio.com/d96385bd-3ed0-4ee5-bebf-1717dbf62e74/_boards/board/t/fc38d75d-0bec-43eb-a290-2f2846700235/Microsoft.RequirementCategory)
 # appbuilder-ci-ios
 
 ## Description


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://a-f-almalki.visualstudio.com/d96385bd-3ed0-4ee5-bebf-1717dbf62e74/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.